### PR TITLE
解决特殊情况下的bug

### DIFF
--- a/library/src/main/java/com/zly/widget/CollapsedTextView.java
+++ b/library/src/main/java/com/zly/widget/CollapsedTextView.java
@@ -39,15 +39,15 @@ public class CollapsedTextView extends AppCompatTextView implements View.OnClick
     /**
      * 默认的折叠行数
      */
-    public static final int COLLAPSED_LINES = 3;
+    public static final int COLLAPSED_LINES = 4;
     /**
      * 折叠时的默认文本
      */
-    private static final String EXPANDED_TEXT = "展开";
+    private static final String EXPANDED_TEXT = "展开全文";
     /**
      * 展开时的默认文本
      */
-    private static final String COLLAPSED_TEXT = "收起";
+    private static final String COLLAPSED_TEXT = "收起全文";
     /**
      * 在文本末尾
      */
@@ -184,7 +184,7 @@ public class CollapsedTextView extends AppCompatTextView implements View.OnClick
      * @param collapsedText 提示文本
      */
     public void setCollapsedText(String collapsedText) {
-        this.mCollapsedText = collapsedText;
+        this.mCollapsedText = collapsedText == null ? COLLAPSED_TEXT : collapsedText;
     }
 
     /**

--- a/library/src/main/java/com/zly/widget/CollapsedTextView.java
+++ b/library/src/main/java/com/zly/widget/CollapsedTextView.java
@@ -39,15 +39,15 @@ public class CollapsedTextView extends AppCompatTextView implements View.OnClick
     /**
      * 默认的折叠行数
      */
-    public static final int COLLAPSED_LINES = 4;
+    public static final int COLLAPSED_LINES = 3;
     /**
      * 折叠时的默认文本
      */
-    private static final String EXPANDED_TEXT = "展开全文";
+    private static final String EXPANDED_TEXT = "展开";
     /**
      * 展开时的默认文本
      */
-    private static final String COLLAPSED_TEXT = "收起全文";
+    private static final String COLLAPSED_TEXT = "收起";
     /**
      * 在文本末尾
      */
@@ -184,7 +184,7 @@ public class CollapsedTextView extends AppCompatTextView implements View.OnClick
      * @param collapsedText 提示文本
      */
     public void setCollapsedText(String collapsedText) {
-        this.mCollapsedText = TextUtils.isEmpty(collapsedText) ? COLLAPSED_TEXT : collapsedText;
+        this.mCollapsedText = collapsedText;
     }
 
     /**
@@ -329,6 +329,9 @@ public class CollapsedTextView extends AppCompatTextView implements View.OnClick
             // 如果大于屏幕宽度则需要减去部分字符
             if (lastLineWidth + expandedTextWidth > mShowWidth) {
                 int cutCount = paint.breakText(mOriginalText, lastLineStart, lastLineEnd, false, expandedTextWidth, null);
+                while (paint.measureText(mOriginalText.subSequence(lastLineStart, lastLineEnd - cutCount) + ELLIPSE + " " + mExpandedText) > mShowWidth) {
+                    cutCount++;
+                }
                 lastLineEnd -= cutCount;
             }
             // 因设置的文本可能是带有样式的文本，如SpannableStringBuilder，所以根据计算的字符数从原始文本中截取


### PR DESCRIPTION
处理遇到因为英文字符导致末尾的给展开预留的位置不够而换行，以及通过设置collapsedText==“”，而放弃收起功能